### PR TITLE
Add initial base plugin code for Artifact Swap

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -11,4 +11,16 @@ repositories {
 
 dependencies {
     testImplementation(kotlin("test"))
+    testImplementation(gradleTestKit())
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
+}
+
+gradlePlugin {
+    plugins {
+        create("artifactSwapPlugin") {
+            id = "xyz.block.artifactswap"
+            implementationClass = "xyz.block.artifactswap.gradle.ArtifactSwapSettingsPlugin"
+        }
+    }
 }

--- a/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/ArtifactSwapExtension.kt
+++ b/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/ArtifactSwapExtension.kt
@@ -1,0 +1,39 @@
+package xyz.block.artifactswap.gradle
+
+import org.gradle.api.provider.Property
+import java.io.File
+
+/**
+ * Configuration extension for the Artifact Swap plugin.
+ *
+ * Users can configure this in their settings.gradle.kts:
+ * ```
+ * artifactSwap {
+ *   mavenGroup.set("com.example.artifacts")
+ *   bomVersion.set("1.0.0")
+ *   localRepositoryPath.set(file("/custom/path/to/repo"))
+ * }
+ * ```
+ */
+interface ArtifactSwapExtension {
+  /**
+   * The Maven group ID used for artifact swap dependencies.
+   *
+   * Example: "com.example.artifacts"
+   */
+  val mavenGroup: Property<String>
+
+  /**
+   * The version of the BOM (Bill of Materials) to use for dependency resolution.
+   *
+   * Example: "1.0.0"
+   */
+  val bomVersion: Property<String>
+
+  /**
+   * The path to the local Maven repository where artifacts are stored.
+   *
+   * Defaults to ~/.m2/repository
+   */
+  val localRepositoryPath: Property<File>
+}

--- a/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/ArtifactSwapProjectPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/ArtifactSwapProjectPlugin.kt
@@ -1,0 +1,108 @@
+package xyz.block.artifactswap.gradle
+
+import xyz.block.artifactswap.gradle.services.artifactSwapBomService
+import xyz.block.artifactswap.gradle.services.artifactSwapConfigService
+import xyz.block.artifactswap.gradle.services.services
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.DependencySubstitution
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+
+/**
+ * Artifact Swap project sub-plugin. This plugin is responsible for performing dependency substitution
+ *
+ * This plugin should not be applied directly. It is auto-applied by [ArtifactSwapSettingsPlugin].
+ * For reference and searchability, the ID of this plugin is `xyz.block.artifactswap`.
+ */
+@Suppress("unused")
+class ArtifactSwapProjectPlugin : Plugin<Project> {
+  override fun apply(target: Project) = target.run {
+    // Get configuration from the config service
+    val configService = gradle.services.artifactSwapConfigService
+    val bomService = gradle.services.artifactSwapBomService
+
+    // Gather all necessary data for the substitution strategy
+    val includedProjects = collectIncludedProjects()
+
+    // Create the substitution strategy with pure logic (easily testable)
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = configService.mavenGroup,
+      bomVersionMap = bomService.bomVersionMap,
+      includedProjects = includedProjects
+    )
+
+    // Apply substitutions using Gradle APIs
+    substituteAllDependencies {
+      val requested = requested as? ModuleComponentSelector ?: return@substituteAllDependencies
+
+      // Given a project structure like this:
+      //
+      // :hobbits
+      //   implementation project(':isengard')
+      // :isengard
+      //   implementation project(':mordor')
+      // :mordor
+      //
+      // If a user requests to swap only `:hobits` and `:mordor`, `:isengard` is replaced by
+      // ArtifactSwapSettingsPlugin with a maven reference to `com.squareup.register.sandbags:isengard`.
+      //
+      // The `com.squareup.sandbags:isengard` artifact will have a dependency on the
+      // `com.squareup.sandbags:mordor` artifact. Since `:mordor` is included in the build, we
+      // need to update the `com.squareup.sandbags:isengard` dependency to point to
+      // `project(':mordor')`. Doing this update ensures that if the developer modifies `:mordor`,
+      // those edits take effect everywhere that uses `:mordor` code, aka in regular gradle projects
+      // and published artifacts. If we did not perform this substitution, the published artifact
+      // would not respond to changes in `:mordor`.
+
+      when (val decision = strategy.decide(requested.group, requested.module)) {
+        is SubstitutionDecision.NoSubstitution -> {
+          // Do nothing - keep the original dependency
+        }
+        is SubstitutionDecision.UseProject -> {
+          // Substitute with the local project
+          findProject(decision.projectPath)?.let { useTarget(it) }
+        }
+        is SubstitutionDecision.UseMavenArtifact -> {
+          // Force Gradle to use the BOM specified version for this artifact.
+          // Artifacts are only published when their source changes, so their POM references the
+          // artifact versions of other projects at the time of publication. Referenced projects
+          // may change and be re-published, so these versions contained in the artifact POM may
+          // become out-of-date. The Artifact Swap BOM contains the most recent versions of each
+          // artifact so we use that as our source of truth.
+          useTarget(decision.coordinates)
+        }
+      }
+      // TODO: In the future, we should rewrite all of the dependencies of artifacts to the
+      //  current versions used by the build as specified by dependencies.gradle, or in the
+      //  future, the version catalog. We anticipate external lib dependencies to change less
+      // often than the set of modules a developer is targeting for current work, so we hold
+      // off on that here and expect there to be few issues for the time being.
+    }
+  }
+
+  /**
+   * Collects all project paths that are included in the current build.
+   */
+  private fun Project.collectIncludedProjects(): Set<String> {
+    return gradle.includedBuilds.flatMap { it.projectDir.listFiles()?.toList() ?: emptyList() }
+      .mapNotNull { it.name.takeIf { name -> name.startsWith(":") } }
+      .toSet() + rootProject.allprojects.map { it.path }.toSet()
+  }
+}
+
+/**
+ * The Gradle DSL for this is obnoxiously deeply nested, so just abstract it into a simple wrapper DSL
+ */
+private fun Project.substituteAllDependencies(substitution: DependencySubstitution.() -> Unit) {
+  configurations.configureEach { configs ->
+    if (configs.isCanBeResolved) {
+      configs.resolutionStrategy { resolution ->
+        resolution.dependencySubstitution { subs ->
+          subs.all substitution@{ dep ->
+            dep.substitution()
+          }
+        }
+      }
+    }
+  }
+}

--- a/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/ArtifactSwapSettingsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/ArtifactSwapSettingsPlugin.kt
@@ -1,0 +1,55 @@
+package xyz.block.artifactswap.gradle
+
+import xyz.block.artifactswap.gradle.services.ArtifactSwapBomService
+import xyz.block.artifactswap.gradle.services.ArtifactSwapConfigService
+import xyz.block.artifactswap.gradle.services.services
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+import java.io.File
+
+/**
+ * Settings plugin for Artifact Swap. Apply this in settings.gradle.kts:
+ *
+ * ```
+ * plugins {
+ *   id("xyz.block.artifactswap")
+ * }
+ *
+ * artifactSwap {
+ *   mavenGroup.set("com.example.artifacts")
+ *   bomVersion.set("1.0.0")
+ *   localRepositoryPath.set(file("~/.m2/repository"))
+ * }
+ * ```
+ *
+ * This plugin will automatically apply [ArtifactSwapProjectPlugin] to all projects.
+ */
+@Suppress("unused")
+class ArtifactSwapSettingsPlugin : Plugin<Settings> {
+  override fun apply(settings: Settings) = settings.run {
+    // Register the configuration extension
+    val extension = extensions.create("artifactSwap", ArtifactSwapExtension::class.java)
+
+    // Set default values
+    extension.localRepositoryPath.convention(
+      File(System.getProperty("user.home"), ".m2/repository")
+    )
+
+    // Register the configuration service
+    gradle.services.register(ArtifactSwapConfigService.KEY) { spec ->
+      spec.parameters.mavenGroup.set(extension.mavenGroup)
+    }
+
+    // Register the BOM service with configuration from the extension
+    gradle.services.register(ArtifactSwapBomService.KEY) { spec ->
+      spec.parameters.mavenGroup.set(extension.mavenGroup)
+      spec.parameters.bomVersion.set(extension.bomVersion)
+      spec.parameters.localRepositoryPath.set(extension.localRepositoryPath)
+    }
+
+    // Auto-apply the project plugin to all projects
+    gradle.allprojects { project ->
+      project.plugins.apply(ArtifactSwapProjectPlugin::class.java)
+    }
+  }
+}

--- a/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/DependencySubstitutionStrategy.kt
+++ b/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/DependencySubstitutionStrategy.kt
@@ -1,0 +1,68 @@
+package xyz.block.artifactswap.gradle
+
+/**
+ * Core logic for deciding how to substitute dependencies when artifacts and
+ * projects are mixed together in a build.
+ *
+ * Note, this class is independent of Gradle APIs to allow for easy unit testing.
+ */
+class DependencySubstitutionStrategy(
+  private val artifactSwapMavenGroup: String,
+  private val bomVersionMap: Map<String, String>,
+  private val includedProjects: Set<String>
+) {
+  /**
+   * Determines how a dependency should be substituted based on its group and module.
+   *
+   * @param group The dependency group (e.g., "com.example.artifactswap.artifacts")
+   * @param module The dependency module/artifact name (e.g. "my_gradle_module_path")
+   * @return A [SubstitutionDecision] indicating what action to take
+   */
+  fun decide(group: String?, module: String?): SubstitutionDecision {
+    // Only substitute if the group matches our artifact swap group
+    if (group != artifactSwapMavenGroup || module == null) {
+      return SubstitutionDecision.NoSubstitution
+    }
+
+    // Convert module name to project path (e.g., "foo_bar" -> ":foo:bar")
+    val projectPath = module.toProjectPath()
+
+    // If the project is included in the build, substitute with the project
+    if (projectPath in includedProjects) {
+      return SubstitutionDecision.UseProject(projectPath)
+    }
+
+    // Otherwise, use the BOM version for the maven artifact
+    val version = bomVersionMap[module]
+    return if (version != null) {
+      SubstitutionDecision.UseMavenArtifact("$group:$module:$version")
+    } else {
+      // If no version in BOM, don't substitute
+      SubstitutionDecision.NoSubstitution
+    }
+  }
+
+  /**
+   * Converts a module name to a project path.
+   * Example: "foo_bar" -> ":foo:bar"
+   */
+  private fun String.toProjectPath(): String =
+    replace("_", ":").prefixIfNot(":")
+
+  private fun String.prefixIfNot(prefix: String): String =
+    if (startsWith(prefix)) this else "$prefix$this"
+}
+
+/**
+ * Represents the decision for how to substitute a dependency.
+ */
+sealed interface SubstitutionDecision {
+  /** No substitution should be performed */
+  object NoSubstitution : SubstitutionDecision
+
+  /** Substitute with a local project */
+  data class UseProject(val projectPath: String) : SubstitutionDecision
+
+  /** Substitute with a maven artifact at a specific version */
+  data class UseMavenArtifact(val coordinates: String) : SubstitutionDecision
+}

--- a/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/services/ArtifactSwapBomService.kt
+++ b/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/services/ArtifactSwapBomService.kt
@@ -1,0 +1,68 @@
+package xyz.block.artifactswap.gradle.services
+
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.Path
+import kotlin.io.path.exists
+import kotlin.io.path.inputStream
+
+// Service to parse local BOM file once per gradle build
+abstract class ArtifactSwapBomService : BuildService<ArtifactSwapBomService.Parameters> {
+  private companion object {
+    val logger: Logger = Logging.getLogger(ArtifactSwapBomService::class.java)
+  }
+
+  interface Parameters : BuildServiceParameters {
+    /**
+     * The Maven group ID used for artifact swap dependencies.
+     */
+    val mavenGroup: Property<String>
+
+    /**
+     * The version of the BOM to use.
+     */
+    val bomVersion: Property<String>
+
+    /**
+     * The path to the local Maven repository.
+     */
+    val localRepositoryPath: Property<File>
+  }
+
+  object KEY : SharedServiceKey<ArtifactSwapBomService, ArtifactSwapBomService.Parameters>("artifactSwapBom")
+
+  private val bomFile: Path
+    get() {
+      val bomVersion = parameters.bomVersion.get()
+      val mavenGroup = parameters.mavenGroup.get()
+      val repoPath = parameters.localRepositoryPath.get().toPath()
+
+      return repoPath
+        .resolve(mavenGroup.replace(".", "/"))
+        .resolve("bom/$bomVersion/bom-$bomVersion.pom")
+    }
+
+  val bomVersionMap by lazy {
+    if (bomFile.exists()) {
+      val pom = bomFile.inputStream().use { XmlSlurper().parse(it) }
+      // https://maven.apache.org/pom.html
+      val dependencyManagement = pom.getProperty("dependencyManagement") as GPathResult
+      val dependencies = dependencyManagement.getProperty("dependencies") as GPathResult
+      val dependencySequence = dependencies.children().asSequence().filterIsInstance<GPathResult>()
+      dependencySequence
+        .associate { it.getProperty("artifactId").toString() to it.getProperty("version").toString() }
+    } else {
+      logger.error("Artifact Swap bom does not exist: {}", bomFile)
+      emptyMap()
+    }
+  }
+}
+
+val SharedServices.artifactSwapBomService get() = get(ArtifactSwapBomService.KEY)

--- a/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/services/ArtifactSwapConfigService.kt
+++ b/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/services/ArtifactSwapConfigService.kt
@@ -1,0 +1,29 @@
+package xyz.block.artifactswap.gradle.services
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
+/**
+ * Build service that holds the configuration for Artifact Swap.
+ * This is separate from the BOM service to keep concerns separated.
+ */
+abstract class ArtifactSwapConfigService : BuildService<ArtifactSwapConfigService.Parameters> {
+
+  interface Parameters : BuildServiceParameters {
+    /**
+     * The Maven group ID used for artifact swap dependencies.
+     */
+    val mavenGroup: Property<String>
+  }
+
+  object KEY : SharedServiceKey<ArtifactSwapConfigService, ArtifactSwapConfigService.Parameters>("artifactSwapConfig")
+
+  /**
+   * The configured Maven group for artifact swap dependencies.
+   */
+  val mavenGroup: String
+    get() = parameters.mavenGroup.get()
+}
+
+val SharedServices.artifactSwapConfigService get() = get(ArtifactSwapConfigService.KEY)

--- a/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/services/SharedServices.kt
+++ b/gradle-plugin/src/main/kotlin/xyz.block.artifactswap.gradle/services/SharedServices.kt
@@ -1,0 +1,61 @@
+@file:Suppress("UnstableApiUsage")
+package xyz.block.artifactswap.gradle.services
+
+import org.gradle.api.invocation.Gradle
+import org.gradle.api.provider.Provider
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.api.services.BuildServiceRegistry
+import org.gradle.api.services.BuildServiceSpec
+
+val Gradle.services: SharedServices
+  get() = SharedServices(this)
+
+/**
+ * Wrapper around [BuildServiceRegistry] providing better registration and reference of services.
+ *
+ * These services are shared by *all* Gradle projects by default, and should be careful to properly
+ * ensure thread-safe access where necessary.
+ */
+class SharedServices(private val gradle: Gradle) {
+
+  /**
+   * Registers a new service by the provided [key] and allows lazy configuration of the service.
+   *
+   * Only the first service registered per [name][SharedServiceKey.name] will be used for lookup.
+   * It is an error to use the same name for multiple services of different types.
+   */
+  inline fun <reified T : BuildService<P>, P : BuildServiceParameters> register(
+    key: SharedServiceKey<T, P>,
+    noinline configure: (BuildServiceSpec<P>) -> Unit = { }
+  ): Provider<T> {
+    return register(key, T::class.java, configure)
+  }
+
+  /** See [register(key, configure)][register]. */
+  fun <T : BuildService<P>, P : BuildServiceParameters> register(
+    key: SharedServiceKey<T, P>,
+    clazz: Class<T>,
+    configure: (BuildServiceSpec<P>) -> Unit = { }
+  ): Provider<T> {
+    return gradle.sharedServices.registerIfAbsent(key.name, clazz) { configure(it) }
+  }
+
+  /** Returns the service registered with the matching [key]. */
+  fun <T : BuildService<P>, P : BuildServiceParameters> get(key: SharedServiceKey<T, P>): T {
+    @Suppress("UNCHECKED_CAST")
+    return gradle.sharedServices.registrations.getAt(key.name).service.get() as T
+  }
+
+  fun <T : BuildService<P>, P : BuildServiceParameters> provider(
+    key: SharedServiceKey<T, P>
+  ): Provider<T> {
+    @Suppress("UNCHECKED_CAST")
+    return gradle.sharedServices.registrations.getAt(key.name).service as Provider<T>
+  }
+}
+
+/** Key used for service registration and lookup. */
+abstract class SharedServiceKey<T : BuildService<P>, P : BuildServiceParameters>(
+  val name: String
+)

--- a/gradle-plugin/src/test/kotlin/xyz.block.artifactswap.gradle/ArtifactSwapPluginIntegrationTest.kt
+++ b/gradle-plugin/src/test/kotlin/xyz.block.artifactswap.gradle/ArtifactSwapPluginIntegrationTest.kt
@@ -1,0 +1,185 @@
+package xyz.block.artifactswap.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for the Artifact Swap plugin using Gradle TestKit.
+ * These tests create real temporary Gradle projects and apply the plugin.
+ */
+class ArtifactSwapPluginIntegrationTest {
+
+  @TempDir
+  lateinit var testProjectDir: File
+
+  private val testMavenGroup = "com.example.test"
+  private val testBomVersion = "1.0.0"
+
+  @Test
+  fun `plugin can be applied successfully`() {
+    // Create settings.gradle.kts
+    settingsFile().writeText("""
+      plugins {
+        id("xyz.block.artifactswap")
+      }
+
+      rootProject.name = "test-project"
+
+      artifactSwap {
+        mavenGroup.set("$testMavenGroup")
+        bomVersion.set("$testBomVersion")
+      }
+    """.trimIndent())
+
+    // Create build.gradle.kts
+    buildFile().writeText("""
+      plugins {
+        kotlin("jvm") version "1.9.0"
+      }
+    """.trimIndent())
+
+    // Run a simple task to verify the plugin applies without errors
+    val result = GradleRunner.create()
+      .withProjectDir(testProjectDir)
+      .withArguments("tasks", "--stacktrace")
+      .withPluginClasspath()
+      .build()
+
+    assertEquals(TaskOutcome.SUCCESS, result.task(":tasks")?.outcome)
+  }
+
+  @Test
+  fun `plugin creates configuration extension`() {
+    // Create settings.gradle.kts that accesses the extension
+    settingsFile().writeText("""
+      plugins {
+        id("xyz.block.artifactswap")
+      }
+
+      rootProject.name = "test-project"
+
+      artifactSwap {
+        mavenGroup.set("$testMavenGroup")
+        bomVersion.set("$testBomVersion")
+        localRepositoryPath.set(file("custom/path"))
+      }
+
+      // Verify we can read the values back
+      println("Maven Group: ${'$'}{artifactSwap.mavenGroup.get()}")
+      println("BOM Version: ${'$'}{artifactSwap.bomVersion.get()}")
+    """.trimIndent())
+
+    buildFile().writeText("""
+      plugins {
+        kotlin("jvm") version "1.9.0"
+      }
+    """.trimIndent())
+
+    val result = GradleRunner.create()
+      .withProjectDir(testProjectDir)
+      .withArguments("tasks", "--quiet")
+      .withPluginClasspath()
+      .build()
+
+    // Verify the configuration values were set correctly
+    assertTrue(result.output.contains("Maven Group: $testMavenGroup"))
+    assertTrue(result.output.contains("BOM Version: $testBomVersion"))
+  }
+
+  @Test
+  fun `plugin applies project plugin to all projects`() {
+    // Create settings.gradle.kts with multiple projects
+    settingsFile().writeText("""
+      plugins {
+        id("xyz.block.artifactswap")
+      }
+
+      rootProject.name = "test-project"
+      include(":subproject1")
+      include(":subproject2")
+
+      artifactSwap {
+        mavenGroup.set("$testMavenGroup")
+        bomVersion.set("$testBomVersion")
+      }
+    """.trimIndent())
+
+    // Create root build file
+    buildFile().writeText("""
+      plugins {
+        kotlin("jvm") version "1.9.0"
+      }
+
+      allprojects {
+        // Check if ArtifactSwapProjectPlugin is applied
+        plugins.withId("xyz.block.artifactswap") {
+          println("Plugin applied to: ${'$'}project.name")
+        }
+      }
+    """.trimIndent())
+
+    // Create subproject directories
+    File(testProjectDir, "subproject1").apply {
+      mkdirs()
+      resolve("build.gradle.kts").writeText("// Empty build file")
+    }
+    File(testProjectDir, "subproject2").apply {
+      mkdirs()
+      resolve("build.gradle.kts").writeText("// Empty build file")
+    }
+
+    val result = GradleRunner.create()
+      .withProjectDir(testProjectDir)
+      .withArguments("tasks", "--quiet")
+      .withPluginClasspath()
+      .build()
+
+    // Note: The project plugin is auto-applied by the settings plugin,
+    // but won't show up with plugins.withId because it's applied programmatically
+    // This test mainly verifies that the multi-project structure works without errors
+    assertEquals(TaskOutcome.SUCCESS, result.task(":tasks")?.outcome)
+  }
+
+  @Test
+  fun `plugin sets default repository path`() {
+    settingsFile().writeText("""
+      plugins {
+        id("xyz.block.artifactswap")
+      }
+
+      rootProject.name = "test-project"
+
+      artifactSwap {
+        mavenGroup.set("$testMavenGroup")
+        bomVersion.set("$testBomVersion")
+        // Don't set localRepositoryPath - should use default
+      }
+
+      // Print the default value
+      println("Repo Path: ${'$'}{artifactSwap.localRepositoryPath.get()}")
+    """.trimIndent())
+
+    buildFile().writeText("""
+      plugins {
+        kotlin("jvm") version "1.9.0"
+      }
+    """.trimIndent())
+
+    val result = GradleRunner.create()
+      .withProjectDir(testProjectDir)
+      .withArguments("tasks", "--quiet")
+      .withPluginClasspath()
+      .build()
+
+    // Verify the default path contains .m2/repository
+    assertTrue(result.output.contains(".m2${File.separator}repository"))
+  }
+
+  private fun settingsFile() = File(testProjectDir, "settings.gradle.kts")
+  private fun buildFile() = File(testProjectDir, "build.gradle.kts")
+}

--- a/gradle-plugin/src/test/kotlin/xyz.block.artifactswap.gradle/DependencySubstitutionStrategyTest.kt
+++ b/gradle-plugin/src/test/kotlin/xyz.block.artifactswap.gradle/DependencySubstitutionStrategyTest.kt
@@ -1,0 +1,216 @@
+package xyz.block.artifactswap.gradle
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class DependencySubstitutionStrategyTest {
+
+  private val testMavenGroup = "com.example.test"
+  private val testBomVersionMap = mapOf(
+    "module-a" to "1.0.0",
+    "module-b" to "2.0.0",
+    "nested_module" to "3.0.0"
+  )
+
+  @Test
+  fun `should not substitute when group doesn't match`() {
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = testMavenGroup,
+      bomVersionMap = testBomVersionMap,
+      includedProjects = setOf(":module-a")
+    )
+
+    val decision = strategy.decide(
+      group = "different.group",
+      module = "module-a"
+    )
+
+    assertIs<SubstitutionDecision.NoSubstitution>(decision)
+  }
+
+  @Test
+  fun `should not substitute when group is null`() {
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = testMavenGroup,
+      bomVersionMap = testBomVersionMap,
+      includedProjects = setOf(":module-a")
+    )
+
+    val decision = strategy.decide(
+      group = null,
+      module = "module-a"
+    )
+
+    assertIs<SubstitutionDecision.NoSubstitution>(decision)
+  }
+
+  @Test
+  fun `should not substitute when module is null`() {
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = testMavenGroup,
+      bomVersionMap = testBomVersionMap,
+      includedProjects = setOf(":module-a")
+    )
+
+    val decision = strategy.decide(
+      group = testMavenGroup,
+      module = null
+    )
+
+    assertIs<SubstitutionDecision.NoSubstitution>(decision)
+  }
+
+  @Test
+  fun `should substitute with project when project is included`() {
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = testMavenGroup,
+      bomVersionMap = testBomVersionMap,
+      includedProjects = setOf(":module-a", ":module-b")
+    )
+
+    val decision = strategy.decide(
+      group = testMavenGroup,
+      module = "module-a"
+    )
+
+    assertIs<SubstitutionDecision.UseProject>(decision)
+    assertEquals(":module-a", decision.projectPath)
+  }
+
+  @Test
+  fun `should substitute with maven artifact when project is not included`() {
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = testMavenGroup,
+      bomVersionMap = testBomVersionMap,
+      includedProjects = setOf(":other-module")
+    )
+
+    val decision = strategy.decide(
+      group = testMavenGroup,
+      module = "module-a"
+    )
+
+    assertIs<SubstitutionDecision.UseMavenArtifact>(decision)
+    assertEquals("com.example.test:module-a:1.0.0", decision.coordinates)
+  }
+
+  @Test
+  fun `should handle nested module names with underscores`() {
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = testMavenGroup,
+      bomVersionMap = testBomVersionMap,
+      includedProjects = setOf(":nested:module")
+    )
+
+    val decision = strategy.decide(
+      group = testMavenGroup,
+      module = "nested_module"
+    )
+
+    assertIs<SubstitutionDecision.UseProject>(decision)
+    assertEquals(":nested:module", decision.projectPath)
+  }
+
+  @Test
+  fun `should use maven artifact with BOM version for deeply nested module`() {
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = testMavenGroup,
+      bomVersionMap = mapOf("foo_bar_baz" to "4.5.6"),
+      includedProjects = emptySet()
+    )
+
+    val decision = strategy.decide(
+      group = testMavenGroup,
+      module = "foo_bar_baz"
+    )
+
+    assertIs<SubstitutionDecision.UseMavenArtifact>(decision)
+    assertEquals("com.example.test:foo_bar_baz:4.5.6", decision.coordinates)
+  }
+
+  @Test
+  fun `should not substitute when module not in BOM and not included`() {
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = testMavenGroup,
+      bomVersionMap = testBomVersionMap,
+      includedProjects = emptySet()
+    )
+
+    val decision = strategy.decide(
+      group = testMavenGroup,
+      module = "unknown-module"
+    )
+
+    assertIs<SubstitutionDecision.NoSubstitution>(decision)
+  }
+
+  @Test
+  fun `should prefer project over maven even when both are available`() {
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = testMavenGroup,
+      bomVersionMap = testBomVersionMap,
+      includedProjects = setOf(":module-a")
+    )
+
+    val decision = strategy.decide(
+      group = testMavenGroup,
+      module = "module-a"
+    )
+
+    // Should use the local project, not the maven artifact
+    assertIs<SubstitutionDecision.UseProject>(decision)
+    assertEquals(":module-a", decision.projectPath)
+  }
+
+  @Test
+  fun `should handle empty BOM map`() {
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = testMavenGroup,
+      bomVersionMap = emptyMap(),
+      includedProjects = setOf(":module-a")
+    )
+
+    val decision = strategy.decide(
+      group = testMavenGroup,
+      module = "module-a"
+    )
+
+    // Should still substitute with project
+    assertIs<SubstitutionDecision.UseProject>(decision)
+  }
+
+  @Test
+  fun `should handle empty included projects`() {
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = testMavenGroup,
+      bomVersionMap = testBomVersionMap,
+      includedProjects = emptySet()
+    )
+
+    val decision = strategy.decide(
+      group = testMavenGroup,
+      module = "module-a"
+    )
+
+    // Should use maven artifact since no projects are included
+    assertIs<SubstitutionDecision.UseMavenArtifact>(decision)
+  }
+
+  @Test
+  fun `should correctly convert module names to project paths`() {
+    val strategy = DependencySubstitutionStrategy(
+      artifactSwapMavenGroup = testMavenGroup,
+      bomVersionMap = emptyMap(),
+      includedProjects = setOf(":a:b:c:d")
+    )
+
+    val decision = strategy.decide(
+      group = testMavenGroup,
+      module = "a_b_c_d"
+    )
+
+    assertIs<SubstitutionDecision.UseProject>(decision)
+    assertEquals(":a:b:c:d", decision.projectPath)
+  }
+}


### PR DESCRIPTION
This PR introduces some initial code for the Artifact Swap gradle plugin. The first pass focuses on code that manages properly setting dependencies for projects being built with Artifact Swap that contain a mix of gradle projects and swapped artifacts.

The nuance in this situation comes from needing to ensure that changes to the project are correctly reflected in both the active gradle modules *and* the artifacts that are participating in the build. The artifacts are built in a way where they depend on other artifacts. This means that, by default, the artifacts will not respond to changes in the underlying modules that they depend on (because their dependency points to a static artifact). This can lead to problems where a change in an active/synced module that breaks an artifact doesn't trigger a compilation failure. To avoid this, we want to wire dependencies together so that artifacts know about active modules and active modules know about artifacts. This involves doing dependency substitution in artifacts to have the dependencies point to whatever active modules exist in the project.

Added unit tests for the core logic of dependency substitution along with some very basic integration tests that verify the settings plugin can be applied as expected. 

Should be testable via:
```
./gradlew :gradle-plugin:build
```